### PR TITLE
Added support for client certificate-based authentication

### DIFF
--- a/lib/k8s.js
+++ b/lib/k8s.js
@@ -18,8 +18,10 @@ var VcapClient = module.exports = function (info) {
         info.version = 'v1';
     }
 
-    if (info.protocol == 'https' && !info.token && !(info.clientKey && info.clientCert && info.caFile)) {
+    if (info.protocol == 'https' && !info.token && !info.clientKey && !info.clientCert && !info.caFile ) {
         return new TypeError('token or clientKey, clientCert, and caFile must be provided as the protocol is https');
+    } else {
+      console.log("arguments are good to go")
     }
 
     if (! info.namespace){

--- a/lib/k8s.js
+++ b/lib/k8s.js
@@ -18,7 +18,7 @@ var VcapClient = module.exports = function (info) {
         info.version = 'v1';
     }
 
-    if (info.protocol == 'https' && !info.token && !(info.clientKey && info.clientCert && info.caFile) {
+    if (info.protocol == 'https' && !info.token && !(info.clientKey && info.clientCert && info.caFile)) {
         return new TypeError('token or clientKey, clientCert, and caFile must be provided as the protocol is https');
     }
 

--- a/lib/k8s.js
+++ b/lib/k8s.js
@@ -18,8 +18,8 @@ var VcapClient = module.exports = function (info) {
         info.version = 'v1';
     }
 
-    if (info.protocol == 'https' && !info.token) {
-        return new TypeError('token must be provided as the protocol is https');
+    if (info.protocol == 'https' && !info.token && !(info.clientKey && info.clientCert && info.caFile) {
+        return new TypeError('token or clientKey, clientCert, and caFile must be provided as the protocol is https');
     }
 
     if (! info.namespace){

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,4 +1,5 @@
 var errors  = require('./errors')
+  , fs = require('fs')
   , path = require('path')
   , request = require('request')
   , url = require('url')
@@ -12,7 +13,10 @@ module.exports = function (info) {
       , version = info.version
       , token = info.token
       , timeout = info.timeout
-      , namespace = info.namespace;
+      , namespace = info.namespace
+      , clientCert = info.clientCert
+      , clientKey = info.clientKey
+      , caCert = info.caCert;
 
     var getUrl = function (object) {
         var prefix = 'api';
@@ -96,7 +100,11 @@ module.exports = function (info) {
             delete object.page;
         }
         object.strictSSL = false;
-
+        if (clientKey && clientCert) {
+            object.key = fs.readFileSync(clientKey)
+            object.cert = fs.readFileSync(clientCert)
+            object.ca = fs.readFileSync(caCert)
+        }
         return request(object, function (err, resp, body) {
             if (err) {
               console.log('error', require('util').inspect(err))

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,5 +1,4 @@
 var errors  = require('./errors')
-  , fs = require('fs')
   , path = require('path')
   , request = require('request')
   , url = require('url')
@@ -101,9 +100,9 @@ module.exports = function (info) {
         }
         object.strictSSL = caCert ? true : false;
         if (clientKey && clientCert) {
-            object.key = fs.readFileSync(clientKey)
-            object.cert = fs.readFileSync(clientCert)
-            object.ca = fs.readFileSync(caCert)
+            object.cert = clientCert;
+            object.key = clientKey;
+            object.ca = caCert;
         }
         return request(object, function (err, resp, body) {
             if (err) {

--- a/lib/request.js
+++ b/lib/request.js
@@ -99,7 +99,7 @@ module.exports = function (info) {
             object.qs.page = object.page;
             delete object.page;
         }
-        object.strictSSL = false;
+        object.strictSSL = caCert ? true : false;
         if (clientKey && clientCert) {
             object.key = fs.readFileSync(clientKey)
             object.cert = fs.readFileSync(clientCert)


### PR DESCRIPTION
Need client certificate based authentication for newer k8s deployments.  Added optional arguments for the filepaths for the clientKey, clientCert, and caFile.
